### PR TITLE
Huke av for inntektslinje opptjent i periode også for saksbehandler

### DIFF
--- a/src/KorreksjonKvitteringSide/KorreksjonKvitteringSide.tsx
+++ b/src/KorreksjonKvitteringSide/KorreksjonKvitteringSide.tsx
@@ -7,7 +7,9 @@ import VerticalSpacer from '../komponenter/VerticalSpacer';
 import { korreksjonStatusTekst } from '../messages';
 import InformasjonFraAvtalen from '../refusjon/RefusjonSide/InformasjonFraAvtalen';
 import InntekterFraAMeldingen from '../refusjon/RefusjonSide/InntekterFraAMeldingen';
+import InntekterFraAMeldingenGammel from '../refusjon/RefusjonSide/InntekterFraAmeldingenGammel';
 import InntekterFraTiltaketSvar from '../refusjon/RefusjonSide/InntekterFraTiltaketSvar';
+import InntekterFraTiltaketSvarGammel from '../refusjon/RefusjonSide/InntekterFraTiltaketSvarGammel';
 import SummeringBoks from '../refusjon/RefusjonSide/SummeringBoks';
 import Utregning from '../refusjon/RefusjonSide/Utregning';
 import { useHentKorreksjon } from '../services/rest-service';
@@ -31,9 +33,22 @@ const KorreksjonKvitteringSide: FunctionComponent = () => {
                 bedriftKontonummerInnhentetTidspunkt={korreksjon.refusjonsgrunnlag.bedriftKontonummerInnhentetTidspunkt}
             />
             <VerticalSpacer rem={2} />
-            <InntekterFraAMeldingen inntektsgrunnlag={korreksjon.refusjonsgrunnlag.inntektsgrunnlag} />
-            <VerticalSpacer rem={2} />
-            <InntekterFraTiltaketSvar refusjonsgrunnlag={korreksjon.refusjonsgrunnlag} />
+
+            {korreksjon.harTattStillingTilAlleInntektslinjer ? (
+                <>
+                    <InntekterFraAMeldingen
+                        inntektsgrunnlag={korreksjon.refusjonsgrunnlag.inntektsgrunnlag}
+                        kvitteringVisning={true}
+                    />
+                    <VerticalSpacer rem={2} />
+                    <InntekterFraTiltaketSvar refusjonsgrunnlag={korreksjon.refusjonsgrunnlag} />
+                </>
+            ) : (
+                <>
+                    <InntekterFraAMeldingenGammel inntektsgrunnlag={korreksjon.refusjonsgrunnlag.inntektsgrunnlag} />
+                    <InntekterFraTiltaketSvarGammel refusjonsgrunnlag={korreksjon.refusjonsgrunnlag} />
+                </>
+            )}
             <VerticalSpacer rem={2} />
             <Utregning
                 beregning={korreksjon.refusjonsgrunnlag.beregning}

--- a/src/KorreksjonSide/KorreksjonSide.tsx
+++ b/src/KorreksjonSide/KorreksjonSide.tsx
@@ -54,20 +54,28 @@ const KorreksjonSide: FunctionComponent = () => {
                 bedriftKontonummerInnhentetTidspunkt={korreksjon.refusjonsgrunnlag.bedriftKontonummerInnhentetTidspunkt}
             />
             <VerticalSpacer rem={2} />
-            <InntekterFraAMeldingen inntektsgrunnlag={korreksjon.refusjonsgrunnlag.inntektsgrunnlag} />
+            <InntekterFraAMeldingen
+                inntektsgrunnlag={korreksjon.refusjonsgrunnlag.inntektsgrunnlag}
+                kvitteringVisning={false}
+                korreksjonId={korreksjon.id}
+            />
             <VerticalSpacer rem={2} />
-            <InntekterFraTiltaketSpørsmål refusjonsgrunnlag={korreksjon.refusjonsgrunnlag} />
-            <VerticalSpacer rem={2} />
-            {korreksjon.refusjonsgrunnlag.beregning && (
+            {korreksjon.harTattStillingTilAlleInntektslinjer && (
                 <>
-                    <Utregning
-                        beregning={korreksjon.refusjonsgrunnlag.beregning}
-                        tilskuddsgrunnlag={korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag}
-                    />
-                    <VerticalSpacer rem={1} />
-                    {korreksjonstype() === 'TILLEGSUTBETALING' && <BekreftUtbetalKorreksjon />}
-                    {korreksjonstype() === 'TILBAKEKREVING' && <BekreftTilbakekrevKorreksjon />}
-                    {korreksjonstype() === 'OPPGJORT' && <BekreftOppgjørKorreksjon />}
+                    <InntekterFraTiltaketSpørsmål refusjonsgrunnlag={korreksjon.refusjonsgrunnlag} />
+                    <VerticalSpacer rem={2} />
+                    {korreksjon.refusjonsgrunnlag.beregning && (
+                        <>
+                            <Utregning
+                                beregning={korreksjon.refusjonsgrunnlag.beregning}
+                                tilskuddsgrunnlag={korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag}
+                            />
+                            <VerticalSpacer rem={1} />
+                            {korreksjonstype() === 'TILLEGSUTBETALING' && <BekreftUtbetalKorreksjon />}
+                            {korreksjonstype() === 'TILBAKEKREVING' && <BekreftTilbakekrevKorreksjon />}
+                            {korreksjonstype() === 'OPPGJORT' && <BekreftOppgjørKorreksjon />}
+                        </>
+                    )}
                 </>
             )}
         </HvitBoks>

--- a/src/refusjon/KvitteringSide/KvitteringSide.tsx
+++ b/src/refusjon/KvitteringSide/KvitteringSide.tsx
@@ -13,7 +13,9 @@ import { storForbokstav } from '../../utils/stringUtils';
 import { Refusjon, RefusjonStatus } from '../refusjon';
 import InformasjonFraAvtalen from '../RefusjonSide/InformasjonFraAvtalen';
 import InntekterFraAMeldingen from '../RefusjonSide/InntekterFraAMeldingen';
+import InntekterFraAMeldingenGammel from '../RefusjonSide/InntekterFraAmeldingenGammel';
 import InntekterFraTiltaketSvar from '../RefusjonSide/InntekterFraTiltaketSvar';
+import InntekterFraTiltaketSvarGammel from '../RefusjonSide/InntekterFraTiltaketSvarGammel';
 import OpprettKorreksjon from '../RefusjonSide/OpprettKorreksjon';
 import SummeringBoks from '../RefusjonSide/SummeringBoks';
 import Utregning from '../RefusjonSide/Utregning';
@@ -55,9 +57,23 @@ const KvitteringSide: FunctionComponent = () => {
                 bedriftKontonummerInnhentetTidspunkt={refusjonsgrunnlag.bedriftKontonummerInnhentetTidspunkt}
             />
             <VerticalSpacer rem={2} />
-            <InntekterFraAMeldingen inntektsgrunnlag={refusjonsgrunnlag.inntektsgrunnlag} />
-            <VerticalSpacer rem={2} />
-            <InntekterFraTiltaketSvar refusjonsgrunnlag={refusjonsgrunnlag} />
+
+            {refusjon.harTattStillingTilAlleInntektslinjer ? (
+                <>
+                    <InntekterFraAMeldingen
+                        inntektsgrunnlag={refusjonsgrunnlag.inntektsgrunnlag}
+                        kvitteringVisning={true}
+                    />
+                    <VerticalSpacer rem={2} />
+                    <InntekterFraTiltaketSvar refusjonsgrunnlag={refusjonsgrunnlag} />
+                </>
+            ) : (
+                <>
+                    <InntekterFraAMeldingenGammel inntektsgrunnlag={refusjonsgrunnlag.inntektsgrunnlag} />
+                    <VerticalSpacer rem={2} />
+                    <InntekterFraTiltaketSvarGammel refusjonsgrunnlag={refusjonsgrunnlag} />
+                </>
+            )}
             <VerticalSpacer rem={2} />
             <Utregning
                 beregning={refusjonsgrunnlag.beregning}

--- a/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraAmeldingenGammel.tsx
@@ -1,12 +1,10 @@
 import _ from 'lodash';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
-import { Radio } from 'nav-frontend-skjema';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import VerticalSpacer from '../../komponenter/VerticalSpacer';
 import { lønnsbeskrivelseTekst } from '../../messages';
-import { setInntektslinjeOpptjentIPeriode } from '../../services/rest-service';
 import { formatterDato, formatterPeriode, NORSK_DATO_OG_TID_FORMAT, NORSK_MÅNEDÅR_FORMAT } from '../../utils/datoUtils';
 import { formatterPenger } from '../../utils/PengeUtils';
 import { Inntektsgrunnlag } from '../refusjon';
@@ -42,7 +40,7 @@ const InntekterTabell = styled.table`
     }
 `;
 
-export const inntektBeskrivelse = (beskrivelse: string | undefined) => {
+const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     if (beskrivelse === undefined) {
         return '';
     } else if (beskrivelse === '') {
@@ -52,13 +50,9 @@ export const inntektBeskrivelse = (beskrivelse: string | undefined) => {
     }
 };
 
-type Props = {
+const InntekterFraAMeldingenGammel: FunctionComponent<{
     inntektsgrunnlag: Inntektsgrunnlag | undefined;
-    kvitteringVisning: boolean;
-    korreksjonId?: string;
-};
-
-const InntekterFraAMeldingen: FunctionComponent<Props> = (props) => {
+}> = (props) => {
     const antallInntekterSomErMedIGrunnlag = props.inntektsgrunnlag?.inntekter.filter(
         (inntekt) => inntekt.erMedIInntektsgrunnlag
     ).length;
@@ -101,7 +95,6 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = (props) => {
                                     <th>Beskriv&shy;else</th>
                                     <th>År/mnd</th>
                                     <th>Opptjenings&shy;periode</th>
-                                    <th>Opptjent i perioden?</th>
                                     <th>Beløp</th>
                                 </tr>
                             </thead>
@@ -128,51 +121,10 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = (props) => {
                                             )}
                                         </td>
 
-                                        {props.inntektsgrunnlag?.inntekter.filter(
-                                            (currInntekt) => currInntekt.erOpptjentIPeriode
-                                        ) && (
-                                            <td>
-                                                {!props.kvitteringVisning && props.korreksjonId && (
-                                                    <div style={{ display: 'flex', columnGap: '3em' }}>
-                                                        <Radio
-                                                            label={'Ja'}
-                                                            checked={inntekt.erOpptjentIPeriode === true}
-                                                            onChange={(e) => {
-                                                                setInntektslinjeOpptjentIPeriode(
-                                                                    props.korreksjonId!,
-                                                                    inntekt.id,
-                                                                    true
-                                                                );
-                                                            }}
-                                                            name={inntekt.id}
-                                                        />
-                                                        <Radio
-                                                            label={'Nei'}
-                                                            checked={inntekt.erOpptjentIPeriode === false}
-                                                            onChange={(e) => {
-                                                                setInntektslinjeOpptjentIPeriode(
-                                                                    props.korreksjonId!,
-                                                                    inntekt.id,
-                                                                    false
-                                                                );
-                                                            }}
-                                                            name={inntekt.id}
-                                                        />
-                                                    </div>
-                                                )}
-                                                {props.kvitteringVisning && (
-                                                    <div style={{ display: 'flex', columnGap: '3em' }}>
-                                                        {inntekt.erOpptjentIPeriode && <label>{'Ja'}</label>}
-                                                        {!inntekt.erOpptjentIPeriode && <label>{'Nei'}</label>}
-                                                    </div>
-                                                )}
-                                            </td>
-                                        )}
-
                                         <td>{formatterPenger(inntekt.beløp)}</td>
                                     </tr>
                                 ))}
-                                {/* {props.inntektsgrunnlag?.bruttoLønn && (
+                                {props.inntektsgrunnlag?.bruttoLønn && (
                                     <tr>
                                         <td colSpan={3}>
                                             <b>Sum</b>
@@ -183,7 +135,7 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = (props) => {
                                             </b>
                                         </td>
                                     </tr>
-                                )} */}
+                                )}
                             </tbody>
                         </InntekterTabell>
                     </>
@@ -228,4 +180,4 @@ const InntekterFraAMeldingen: FunctionComponent<Props> = (props) => {
     );
 };
 
-export default InntekterFraAMeldingen;
+export default InntekterFraAMeldingenGammel;

--- a/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -1,13 +1,15 @@
+import _ from 'lodash';
+import { Input, Label, RadioPanel } from 'nav-frontend-skjema';
+import { Undertittel } from 'nav-frontend-typografi';
 import React, { FunctionComponent, useState } from 'react';
 import { useParams } from 'react-router';
-import { endreBruttolønn } from '../../services/rest-service';
-import { Undertittel } from 'nav-frontend-typografi';
-import { tiltakstypeTekst } from '../../messages';
-import { Input, Label, RadioPanel } from 'nav-frontend-skjema';
 import styled from 'styled-components';
 import VerticalSpacer from '../../komponenter/VerticalSpacer';
+import { tiltakstypeTekst } from '../../messages';
+import { endreBruttolønn } from '../../services/rest-service';
 import { formatterPenger } from '../../utils/PengeUtils';
 import { Refusjonsgrunnlag } from '../refusjon';
+import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
 
 const RadioPakning = styled.div`
     display: flex;
@@ -19,6 +21,12 @@ const RadioPakning = styled.div`
             margin-right: 0;
         }
     }
+`;
+
+export const GrønnBoks = styled.div`
+    background-color: #ccf1d6;
+    padding: 1em;
+    border: 4px solid #99dead;
 `;
 
 const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Refusjonsgrunnlag }> = (props) => {
@@ -39,14 +47,28 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
         }
     };
 
+    // const sumInntekterOpptjentIPeriode = props.refusjonsgrunnlag.inntektsgrunnlag?.inntekter
+    // .filter((inntekt) => inntekt.erOpptjentIPeriode)
+    // .map((el) => el.beløp)
+    // .reduce((el, el2) => el + el2, 0);
+    const inntekterOpptentIPeriode = props.refusjonsgrunnlag.inntektsgrunnlag?.inntekter.filter((inntekt) => inntekt.erOpptjentIPeriode);
+    const sumInntekterOpptjentIPeriode = _.sumBy(inntekterOpptentIPeriode, 'beløp');
+
     return (
-        <div>
+        <GrønnBoks>
             <Undertittel>Inntekter fra {tiltakstypeTekst[refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}</Undertittel>
             <VerticalSpacer rem={1} />
-            <Label htmlFor={'inntekterKunFraTiltaket'}>
-                Er inntektene som vi har hentet ({formatterPenger(refusjonsgrunnlag.inntektsgrunnlag.bruttoLønn)}) kun
-                fra tiltaket {tiltakstypeTekst[refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}?
-            </Label>
+
+            <InntekterOpptjentIPeriodeTabell inntekter={props.refusjonsgrunnlag.inntektsgrunnlag?.inntekter!} />
+
+
+
+            <VerticalSpacer rem={1} />
+                    <Label htmlFor={'inntekterKunFraTiltaket'}>
+                        Er inntektene som du har huket av for{' '}
+                        {sumInntekterOpptjentIPeriode > 0 && <>({formatterPenger(sumInntekterOpptjentIPeriode)})</>} kun
+                        fra tiltaket {tiltakstypeTekst[props.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}?
+                    </Label>
             <p>
                 <i>Du skal svare "nei" hvis noen av inntektene er fra f. eks. vanlig lønn eller lønnstilskudd</i>
             </p>
@@ -85,7 +107,7 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
                     />
                 </>
             )}
-        </div>
+        </GrønnBoks>
     );
 };
 

--- a/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraTiltaketSvar.tsx
@@ -1,42 +1,61 @@
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { Element, Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import React, { FunctionComponent } from 'react';
 import VerticalSpacer from '../../komponenter/VerticalSpacer';
 import { tiltakstypeTekst } from '../../messages';
+import { formatterPeriode } from '../../utils/datoUtils';
 import { formatterPenger } from '../../utils/PengeUtils';
 import { Refusjonsgrunnlag } from '../refusjon';
+import { GrønnBoks } from './InntekterFraTiltaketSpørsmål';
+import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
 
-const InntekterFraTiltaketSvar: FunctionComponent<{ refusjonsgrunnlag: Refusjonsgrunnlag }> = (props) => {
-    if (!props.refusjonsgrunnlag.inntektsgrunnlag) {
+type Props = {
+    refusjonsgrunnlag: Refusjonsgrunnlag;
+};
+
+const InntekterFraTiltaketSvar: FunctionComponent<Props> = (props) => {
+    if (
+        props.refusjonsgrunnlag.inntekterKunFraTiltaket === null ||
+        props.refusjonsgrunnlag.inntekterKunFraTiltaket === undefined
+    ) {
         return null;
     }
 
-    const svar = () => {
-        switch (props.refusjonsgrunnlag.inntekterKunFraTiltaket) {
-            case true:
-                return 'Ja';
-            case false:
-                return 'Nei';
-            default:
-                return 'Ikke besvart';
-        }
-    };
+    const valgtBruttoLønn = props.refusjonsgrunnlag.inntektsgrunnlag?.inntekter
+        .filter((inntekt) => inntekt.erOpptjentIPeriode)
+        .map((el) => el.beløp)
+        .reduce((el, el2) => el + el2, 0);
+
+    if (!props.refusjonsgrunnlag.inntektsgrunnlag?.inntekter) {
+        return null;
+    }
 
     return (
         <div>
-            <Element>
-                Er inntektene som vi har hentet (
-                {formatterPenger(props.refusjonsgrunnlag.inntektsgrunnlag!!.bruttoLønn)}) kun fra tiltaket{' '}
-                {tiltakstypeTekst[props.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}?{' '}
-            </Element>
-            <Normaltekst>{svar()}</Normaltekst>
-            {props.refusjonsgrunnlag.endretBruttoLønn !== null &&
-                props.refusjonsgrunnlag.endretBruttoLønn !== undefined && (
-                    <>
-                        <VerticalSpacer rem={1} />
-                        <Element>Korrigert brutto lønn:</Element>
-                        <Normaltekst>{formatterPenger(props.refusjonsgrunnlag.endretBruttoLønn)}</Normaltekst>
-                    </>
-                )}
+            <GrønnBoks>
+                <Undertittel>
+                    Inntekter som refunderes for{' '}
+                    {formatterPeriode(
+                        props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
+                        props.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom
+                    )}
+                </Undertittel>
+                <VerticalSpacer rem={1} />
+                <InntekterOpptjentIPeriodeTabell inntekter={props.refusjonsgrunnlag.inntektsgrunnlag.inntekter} />
+                <VerticalSpacer rem={2} />
+                <Element>
+                    Er inntektene du har valgt ({formatterPenger(valgtBruttoLønn as number)}) kun fra tiltaket{' '}
+                    {tiltakstypeTekst[props.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}?{' '}
+                </Element>
+                <Normaltekst>{props.refusjonsgrunnlag.inntekterKunFraTiltaket ? 'Ja' : 'Nei'}</Normaltekst>
+                {props.refusjonsgrunnlag.endretBruttoLønn !== null &&
+                    props.refusjonsgrunnlag.endretBruttoLønn !== undefined && (
+                        <>
+                            <VerticalSpacer rem={1} />
+                            <Element>Korrigert brutto lønn:</Element>
+                            <Normaltekst>{formatterPenger(props.refusjonsgrunnlag.endretBruttoLønn)}</Normaltekst>
+                        </>
+                    )}
+            </GrønnBoks>
         </div>
     );
 };

--- a/src/refusjon/RefusjonSide/InntekterFraTiltaketSvarGammel.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraTiltaketSvarGammel.tsx
@@ -1,0 +1,44 @@
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+import React, { FunctionComponent } from 'react';
+import VerticalSpacer from '../../komponenter/VerticalSpacer';
+import { tiltakstypeTekst } from '../../messages';
+import { formatterPenger } from '../../utils/PengeUtils';
+import { Refusjonsgrunnlag } from '../refusjon';
+
+const InntekterFraTiltaketSvarGammel: FunctionComponent<{ refusjonsgrunnlag: Refusjonsgrunnlag }> = (props) => {
+    if (!props.refusjonsgrunnlag.inntektsgrunnlag) {
+        return null;
+    }
+
+    const svar = () => {
+        switch (props.refusjonsgrunnlag.inntekterKunFraTiltaket) {
+            case true:
+                return 'Ja';
+            case false:
+                return 'Nei';
+            default:
+                return 'Ikke besvart';
+        }
+    };
+
+    return (
+        <div>
+            <Element>
+                Er inntektene som vi har hentet (
+                {formatterPenger(props.refusjonsgrunnlag.inntektsgrunnlag!!.bruttoLønn)}) kun fra tiltaket{' '}
+                {tiltakstypeTekst[props.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype]}?{' '}
+            </Element>
+            <Normaltekst>{svar()}</Normaltekst>
+            {props.refusjonsgrunnlag.endretBruttoLønn !== null &&
+                props.refusjonsgrunnlag.endretBruttoLønn !== undefined && (
+                    <>
+                        <VerticalSpacer rem={1} />
+                        <Element>Korrigert brutto lønn:</Element>
+                        <Normaltekst>{formatterPenger(props.refusjonsgrunnlag.endretBruttoLønn)}</Normaltekst>
+                    </>
+                )}
+        </div>
+    );
+};
+
+export default InntekterFraTiltaketSvarGammel;

--- a/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
+++ b/src/refusjon/RefusjonSide/InntekterOpptjentIPeriodeTabell.tsx
@@ -1,0 +1,88 @@
+import _ from 'lodash';
+import { Element } from 'nav-frontend-typografi';
+import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { formatterPeriode } from '../../utils/datoUtils';
+import { Inntektslinje } from '../refusjon';
+import { inntektBeskrivelse } from './InntekterFraAMeldingen';
+
+type Props = {
+    inntekter: Inntektslinje[];
+};
+
+const InntekterTabell = styled.table`
+    width: 100%;
+    th,
+    td {
+        text-align: left;
+        padding: 0.35rem 0.5rem;
+    }
+    th:first-child,
+    td:first-child {
+        padding: 0.35rem 0;
+    }
+    th:last-child,
+    td:last-child {
+        text-align: right;
+        padding: 0.35rem 0;
+    }
+`;
+
+const InntekterOpptjentIPeriodeTabell: FunctionComponent<Props> = (props) => {
+    const inntekterHuketAvForOpptjentIPeriode = props.inntekter.filter((inntekt) => inntekt.erOpptjentIPeriode);
+    const sumInntekterOpptjentIPeriode = _.sumBy(inntekterHuketAvForOpptjentIPeriode, 'beløp');
+
+    const sorterInntektslinjer = (inntektslinjer: Inntektslinje[]) =>
+        _.sortBy(inntektslinjer, [
+            'måned',
+            'opptjeningsperiodeFom',
+            'opptjeningsperiodeTom',
+            'opptjent',
+            'beskrivelse',
+            'id',
+        ]);
+
+    return (
+        <div>
+            <InntekterTabell>
+                <thead>
+                    <tr>
+                        <th>Beskriv&shy;else</th>
+                        <th>År/mnd</th>
+                        <th>Opptjeningsperiode</th>
+                        <th>Opptjent i perioden?</th>
+                        <th>Beløp</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sorterInntektslinjer(inntekterHuketAvForOpptjentIPeriode).map((inntekt) => (
+                        <tr key={inntekt.id}>
+                            <td>{inntektBeskrivelse(inntekt.beskrivelse)}</td>
+                            <td>{inntekt.måned}</td>
+                            <td>
+                                {inntekt.opptjeningsperiodeFom && inntekt.opptjeningsperiodeTom ? (
+                                    formatterPeriode(
+                                        inntekt.opptjeningsperiodeFom,
+                                        inntekt.opptjeningsperiodeTom,
+                                        'DD.MM'
+                                    )
+                                ) : (
+                                    <em>Ikke rapportert opptjenings&shy;periode</em>
+                                )}
+                            </td>
+                            <td>{inntekt.erOpptjentIPeriode ? 'Ja' : 'Nei'}</td>
+                            <td>{inntekt.beløp}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </InntekterTabell>
+            <br />
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Element>Sum bruttolønn</Element>
+                <Element>{inntekterHuketAvForOpptjentIPeriode.length >= 1 && sumInntekterOpptjentIPeriode}</Element>
+            </div>
+        </div>
+    );
+};
+
+export default InntekterOpptjentIPeriodeTabell;

--- a/src/refusjon/RefusjonSide/RefusjonSide.tsx
+++ b/src/refusjon/RefusjonSide/RefusjonSide.tsx
@@ -9,7 +9,7 @@ import VerticalSpacer from '../../komponenter/VerticalSpacer';
 import { useHentRefusjon } from '../../services/rest-service';
 import InformasjonFraAvtalen from './InformasjonFraAvtalen';
 import InntekterFraAMeldingen from './InntekterFraAMeldingen';
-import InntekterFraTiltaketSvar from './InntekterFraTiltaketSvar';
+import InntekterFraTiltaketSvarGammel from './InntekterFraTiltaketSvarGammel';
 import './RefusjonSide.less';
 import Utregning from './Utregning';
 
@@ -54,9 +54,12 @@ const RefusjonSide: FunctionComponent = () => {
                 bedriftKontonummerInnhentetTidspunkt={refusjon.refusjonsgrunnlag.bedriftKontonummerInnhentetTidspunkt}
             />
             <VerticalSpacer rem={2} />
-            <InntekterFraAMeldingen inntektsgrunnlag={refusjon.refusjonsgrunnlag.inntektsgrunnlag} />
+            <InntekterFraAMeldingen
+                inntektsgrunnlag={refusjon.refusjonsgrunnlag.inntektsgrunnlag}
+                kvitteringVisning={true}
+            />
             <VerticalSpacer rem={2} />
-            <InntekterFraTiltaketSvar refusjonsgrunnlag={refusjon.refusjonsgrunnlag} />
+            <InntekterFraTiltaketSvarGammel refusjonsgrunnlag={refusjon.refusjonsgrunnlag} />
             <VerticalSpacer rem={2} />
             {refusjon.refusjonsgrunnlag.beregning && (
                 <Utregning

--- a/src/refusjon/refusjon.ts
+++ b/src/refusjon/refusjon.ts
@@ -35,6 +35,7 @@ export interface Refusjon {
     korreksjonId?: string;
     refusjonsgrunnlag: Refusjonsgrunnlag;
     unntakOmInntekterToMånederFrem: boolean;
+    harTattStillingTilAlleInntektslinjer: boolean;
 }
 
 export interface Korreksjon {
@@ -47,6 +48,7 @@ export interface Korreksjon {
     kostnadssted?: string;
     korreksjonsgrunner: Korreksjonsgrunn[];
     refusjonsgrunnlag: Refusjonsgrunnlag;
+    harTattStillingTilAlleInntektslinjer: boolean;
 }
 
 export interface Refusjonsgrunnlag {
@@ -97,6 +99,7 @@ export interface Inntektslinje {
     opptjeningsperiodeFom?: string;
     opptjeningsperiodeTom?: string;
     erMedIInntektsgrunnlag: boolean;
+    erOpptjentIPeriode: boolean;
 }
 
 export interface Beregning {

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -131,3 +131,16 @@ export const fullførKorreksjonVedTilbakekreving = async (korreksjonId: string) 
     await mutate(`/korreksjon/${korreksjonId}`);
     return response.data;
 };
+
+export const setInntektslinjeOpptjentIPeriode = async (
+    korreksjonId: string,
+    inntektslinjeId: string,
+    erOpptjentIPeriode: boolean
+) => {
+    const response = await api.post(`/korreksjon/${korreksjonId}/set-inntektslinje-opptjent-i-periode`, {
+        inntektslinjeId,
+        erOpptjentIPeriode,
+    });
+    await mutate(`/korreksjon/${korreksjonId}`);
+    return response.data;
+};


### PR DESCRIPTION
Funksjonalitet for saksbehandler for å huke av inntektslinjer og sette de til opptjent i perioden på samme måte som det er innført for arbeidsgiver. Samme bakoverkompatible visning for korreksjoner og refusjoner som er gjort før dette ble innført.