### PR TITLE
Advarsel ved mismatch mellom kostnadssted på refusjon og korreksjon.

### DIFF
--- a/src/refusjon/RefusjonSide/BekreftUtbetalKorreksjon.tsx
+++ b/src/refusjon/RefusjonSide/BekreftUtbetalKorreksjon.tsx
@@ -1,9 +1,9 @@
-import React, { FunctionComponent, useState } from 'react';
+import { Alert, BodyShort, Button, Label, TextField } from '@navikt/ds-react';
+import { FunctionComponent, useState } from 'react';
 import { useParams } from 'react-router';
-import BekreftelseModal from '../../komponenter/bekreftelse-modal/BekreftelseModal';
 import VerticalSpacer from '../../komponenter/VerticalSpacer';
-import { useHentKorreksjon, utbetalKorreksjon } from '../../services/rest-service';
-import { BodyShort, TextField, Button } from '@navikt/ds-react';
+import BekreftelseModal from '../../komponenter/bekreftelse-modal/BekreftelseModal';
+import { hentEnhet, useHentKorreksjon, utbetalKorreksjon } from '../../services/rest-service';
 
 const BekreftUtbetalKorreksjon: FunctionComponent = () => {
     const { korreksjonId } = useParams<{ korreksjonId: string }>();
@@ -11,10 +11,38 @@ const BekreftUtbetalKorreksjon: FunctionComponent = () => {
     const [beslutterIdent, setBeslutterIdent] = useState('');
     const [kostnadssted, setKostnadssted] = useState('');
     const korreksjon = useHentKorreksjon(korreksjonId!);
+    const [enhetNavn, setEnhetNavn] = useState<string | null>(null);
+    const [enhetNavnTilskudd, setEnhetNavnTilskudd] = useState<string | null>(null);
+
+    const hentOgSettEnhetNavn = (enhet: string) => {
+        hentEnhet(enhet, korreksjon.id).then((res) => setEnhetNavn(res));
+    };
+
+    const openModal = () => {
+        hentEnhet(korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet, korreksjon.id).then((res) =>
+            setEnhetNavnTilskudd(res)
+        );
+        setisOpen(true);
+    };
+    // if (isOpen && !enhetNavnTilskudd) {
+    //     hentEnhet(korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet, korreksjon.id).then((res) => setEnhetNavnTilskudd(res));
+    // }
+    // useEffect(() => {
+    //     if (isOpen) {
+    //         hentEnhet(korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet, korreksjon.id).then((res) => setEnhetNavnTilskudd(res));
+    //     }
+    // }, [isOpen])
+
+    const visUlikEnhetAdvarsel = () => {
+        if (kostnadssted && kostnadssted.length === 4 && korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet) {
+            return kostnadssted !== korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet;
+        }
+        return false;
+    };
 
     return (
         <div>
-            <Button variant="secondary" onClick={() => setisOpen(true)}>
+            <Button variant="secondary" onClick={() => openModal()}>
                 Send korreksjon til utbetaling
             </Button>
 
@@ -43,19 +71,45 @@ const BekreftUtbetalKorreksjon: FunctionComponent = () => {
                     onChange={(e) => setBeslutterIdent(e.currentTarget.value)}
                 />
                 <VerticalSpacer rem={1} />
-                <TextField
-                    style={{ width: '25%' }}
-                    label="Kostnadssted"
-                    size="small"
-                    value={kostnadssted}
-                    maxLength={4}
-                    onChange={(e) => {
-                        const verdi = e.currentTarget.value;
-                        if (verdi.match(/^\d{0,4}$/)) {
-                            setKostnadssted(verdi);
-                        }
-                    }}
-                />
+                <Label>Kostnadssted</Label>
+                <div style={{ display: 'flex' }}>
+                    <div style={{ width: '9rem' }}>
+                        <TextField
+                            label=""
+                            size="small"
+                            value={kostnadssted}
+                            maxLength={4}
+                            onChange={(e) => {
+                                const verdi = e.currentTarget.value;
+                                if (verdi.match(/^\d{0,4}$/)) {
+                                    setKostnadssted(verdi);
+                                    if (verdi.length === 4) {
+                                        hentOgSettEnhetNavn(verdi);
+                                    } else {
+                                        setEnhetNavn(null);
+                                    }
+                                }
+                            }}
+                        />
+                    </div>
+                    <div style={{ marginLeft: '1rem', marginTop: '0.9rem' }}>
+                        <BodyShort size="small">{enhetNavn}</BodyShort>
+                    </div>
+                </div>
+                {visUlikEnhetAdvarsel() && (
+                    <Alert variant="warning" style={{ marginTop: '1rem' }}>
+                        OBS! Du har valgt at korreksjonen skal kostnadsføres på enhet:{' '}
+                        <b>
+                            {kostnadssted} - {enhetNavn}
+                        </b>
+                        . Dette er ikke samme enhet som refusjonen du korrigerer ble kostnadsført på (
+                        <b>
+                            {korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet} - {enhetNavnTilskudd}
+                        </b>
+                        ).
+                    </Alert>
+                )}
+                <VerticalSpacer rem={1} />
             </BekreftelseModal>
         </div>
     );

--- a/src/refusjon/RefusjonSide/BekreftUtbetalKorreksjon.tsx
+++ b/src/refusjon/RefusjonSide/BekreftUtbetalKorreksjon.tsx
@@ -24,14 +24,6 @@ const BekreftUtbetalKorreksjon: FunctionComponent = () => {
         );
         setisOpen(true);
     };
-    // if (isOpen && !enhetNavnTilskudd) {
-    //     hentEnhet(korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet, korreksjon.id).then((res) => setEnhetNavnTilskudd(res));
-    // }
-    // useEffect(() => {
-    //     if (isOpen) {
-    //         hentEnhet(korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet, korreksjon.id).then((res) => setEnhetNavnTilskudd(res));
-    //     }
-    // }, [isOpen])
 
     const visUlikEnhetAdvarsel = () => {
         if (kostnadssted && kostnadssted.length === 4 && korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.enhet) {

--- a/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektValg.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraAMeldingen/inntektsmeldingTabell/InntektValg.tsx
@@ -1,7 +1,7 @@
+import { Radio, RadioGroup } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
 import { setInntektslinjeOpptjentIPeriode } from '../../../../services/rest-service';
 import { Inntektslinje } from '../../../refusjon';
-import { RadioGroup, Radio } from '@navikt/ds-react';
 
 interface Props {
     inntekt: Inntektslinje;
@@ -10,10 +10,14 @@ interface Props {
 }
 
 const InntektValg: FunctionComponent<Props> = (props) => {
+    let inntektValg = 'Ikke valgt';
+    if (props.inntekt.erOpptjentIPeriode) inntektValg = 'ja';
+    if (props.inntekt.erOpptjentIPeriode === false) inntektValg = 'nei';
+
     return (
         <td>
             {!props.kvitteringVisning && (
-                <RadioGroup legend="" className="inntektsmelding__Inntekt_valg_radio_group">
+                <RadioGroup legend="" className="inntektsmelding__Inntekt_valg_radio_group" value={inntektValg}>
                     <Radio
                         value="ja"
                         checked={props.inntekt.erOpptjentIPeriode}

--- a/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
+++ b/src/refusjon/RefusjonSide/InntekterFraTiltaketSpørsmål.tsx
@@ -1,5 +1,6 @@
+import { Heading, Label, Radio, RadioGroup, TextField } from '@navikt/ds-react';
 import _ from 'lodash';
-import React, { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { useParams } from 'react-router';
 import styled from 'styled-components';
 import VerticalSpacer from '../../komponenter/VerticalSpacer';
@@ -8,7 +9,6 @@ import { endreBruttolønn } from '../../services/rest-service';
 import { formatterPenger } from '../../utils/PengeUtils';
 import { Refusjonsgrunnlag } from '../refusjon';
 import InntekterOpptjentIPeriodeTabell from './InntekterOpptjentIPeriodeTabell';
-import { RadioGroup, Radio, TextField, Label, Heading } from '@navikt/ds-react';
 
 export const GrønnBoks = styled.div`
     background-color: #ccf1d6;
@@ -59,17 +59,17 @@ const InntekterFraTiltaketSpørsmål: FunctionComponent<{ refusjonsgrunnlag: Ref
             <p>
                 <i>Du skal svare "nei" hvis noen av inntektene er fra f. eks. vanlig lønn eller lønnstilskudd</i>
             </p>
-            <RadioGroup legend="">
+            <RadioGroup legend="" value={inntekterKunFraTiltaket}>
                 <Radio 
                     name="inntekterKunFraTiltaket"
-                    value={'ja'}
+                    value={true}
                     checked={inntekterKunFraTiltaket === true}
                     onChange={() => svarPåSpørsmål(true)}
                 >Ja
                 </Radio>
                 <Radio 
                     name="inntekterKunFraTiltaket"
-                    value={'nei'}
+                    value={false}
                     checked={inntekterKunFraTiltaket === false}
                     onChange={() => svarPåSpørsmål(false)}
                     >

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -162,3 +162,8 @@ export const settTidligereRefunderbarBeløp = async (
     await mutate(`/korreksjon/${korreksjonId}`);
     return response.data;
 };
+
+export const hentEnhet = async (enhet: string, korreksjonId: string) => {
+    const response = await api.get<string>(`/korreksjon/${korreksjonId}/hent-enhet/${enhet}`);
+    return response.data;
+};


### PR DESCRIPTION
Viser advarsel hvis man oppgir annen enhet som kostnadssted på korreksjonen enn det som er brukt på refusjonen. Henter også navnet både på kostnadsenheten til refusjonen og det man oppgir i korreksjonen.


![image](https://github.com/navikt/tiltak-refusjon-saksbehandler/assets/5412607/d530b633-492a-4e98-9dde-49a144b9ed47)
