### PR TITLE
Forslag: frist for forlengelse blir rød hvis refusjonen er forlenget maksimalt

### DIFF
--- a/src/refusjon/oversikt/OversiktTabell.tsx
+++ b/src/refusjon/oversikt/OversiktTabell.tsx
@@ -1,4 +1,4 @@
-import { LinkPanel, BodyShort } from '@navikt/ds-react';
+import { BodyShort, LinkPanel } from '@navikt/ds-react';
 import { FunctionComponent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import StatusTekst from '../../komponenter/StatusTekst/StatusTekst';
@@ -82,7 +82,15 @@ const OversiktTabell: FunctionComponent<Props> = (props) => {
                             className={cls.element('title_row_column')}
                             aria-labelledby={cls.element('frist-godkjenning')}
                         >
-                            {formatterDato(refusjon.fristForGodkjenning)}
+                            <span
+                                style={
+                                    refusjon.fristForGodkjenning === refusjon.maksForlengelse
+                                        ? { color: 'red' }
+                                        : undefined
+                                }
+                            >
+                                {formatterDato(refusjon.fristForGodkjenning)}
+                            </span>
                         </BodyShort>
                     </LinkPanel.Title>
                 </LinkPanel>

--- a/src/refusjon/refusjon.ts
+++ b/src/refusjon/refusjon.ts
@@ -39,6 +39,7 @@ export interface Refusjon {
     unntakOmInntekterFremitid: number;
     hentInntekterLengerFrem: string;
     harTattStillingTilAlleInntektslinjer: boolean;
+    maksForlengelse: string;
 }
 
 export interface Korreksjon {


### PR DESCRIPTION
Kjapt forslag til en liten tweak som kan hjelpe på å gjøre det lettere å se hvilke refusjoner som er mulig å forlenge og ikke.
Rød tekst betyr at refusjonen er forlenget maksimalt og kan forlenges ytterligere.

![image](https://github.com/navikt/tiltak-refusjon-saksbehandler/assets/5412607/29d8d08c-78be-4d81-96df-93f33f5af4ab)
