### PR TITLE
Sett manuelt minusbelop

### DIFF
--- a/src/KorreksjonSide/KorreksjonSide.tsx
+++ b/src/KorreksjonSide/KorreksjonSide.tsx
@@ -13,6 +13,7 @@ import InntekterFraTiltaketSpørsmål from '../refusjon/RefusjonSide/InntekterFr
 import Utregning from '../refusjon/RefusjonSide/Utregning';
 import { KorreksjonStatus } from '../refusjon/refusjon';
 import { useHentKorreksjon } from '../services/rest-service';
+import SettManueltMinusbeløp from './SettManueltMinusbeløp';
 import TidligereRefunderbarBeløp from './TidligereRefunderbarBeløp';
 
 const KorreksjonSide: FunctionComponent = () => {
@@ -75,6 +76,7 @@ const KorreksjonSide: FunctionComponent = () => {
                         {korreksjon.refusjonsgrunnlag.beregning &&
                             typeof korreksjon.refusjonsgrunnlag.fratrekkRefunderbarBeløp === 'boolean' && (
                                 <>
+                                    <SettManueltMinusbeløp />
                                     <Utregning
                                         beregning={korreksjon.refusjonsgrunnlag.beregning}
                                         tilskuddsgrunnlag={korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag}

--- a/src/KorreksjonSide/SettManueltMinusbeløp.tsx
+++ b/src/KorreksjonSide/SettManueltMinusbeløp.tsx
@@ -1,8 +1,9 @@
-import { TextField } from '@navikt/ds-react';
+import { Alert, TextField } from '@navikt/ds-react';
 import { ChangeEvent, FunctionComponent, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useFeatureToggles } from '../featureToggles/FeatureToggleProvider';
 import { Feature } from '../featureToggles/features';
+import VerticalSpacer from '../komponenter/VerticalSpacer';
 import { settMinusbeløpManuelt } from '../services/rest-service';
 
 const SettManueltMinusbeløp: FunctionComponent = () => {
@@ -10,27 +11,35 @@ const SettManueltMinusbeløp: FunctionComponent = () => {
     const [belop, setBelop] = useState<string>('');
     const featureToggles = useFeatureToggles();
 
-    if (!featureToggles[Feature.OpprettNullBelopKorreksjon]) {
+    if (!featureToggles[Feature.ManueltMinusbelop]) {
         return null;
     } else {
         return (
-            <div>
-                <TextField
-                    size="small"
-                    label={`Refusjonsbeløpet på grunn av fravær`}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                        const verdi: string = event.currentTarget.value;
-                        if (verdi.match(/^\d*$/)) {
-                            setBelop(verdi);
-                        }
-                        if (!verdi) {
-                            setBelop('');
-                        }
-                    }}
-                    onBlur={() => settMinusbeløpManuelt(korreksjonId!, parseInt(belop, 10))}
-                    value={belop}
-                />
-            </div>
+            <>
+                <VerticalSpacer rem={1} />
+                <div>
+                    <Alert variant="warning">
+                        <TextField
+                            style={{ width: '12rem' }}
+                            size="small"
+                            label="Manuelt minusbeløp"
+                            description="Skriv inn manuelt minusbeløp her. Dette vil bli lagt til i utregningen som om det hadde ligget i minusbeløptabellen"
+                            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                                const verdi: string = event.currentTarget.value;
+                                if (verdi.match(/^[?-]\d*$/)) {
+                                    setBelop(verdi);
+                                }
+                                if (!verdi) {
+                                    setBelop('');
+                                }
+                            }}
+                            onBlur={() => settMinusbeløpManuelt(korreksjonId!, parseInt(belop, 10))}
+                            value={belop}
+                        />
+                    </Alert>
+                </div>
+                <VerticalSpacer rem={1} />
+            </>
         );
     }
 };

--- a/src/KorreksjonSide/SettManueltMinusbeløp.tsx
+++ b/src/KorreksjonSide/SettManueltMinusbeløp.tsx
@@ -1,0 +1,38 @@
+import { TextField } from '@navikt/ds-react';
+import { ChangeEvent, FunctionComponent, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useFeatureToggles } from '../featureToggles/FeatureToggleProvider';
+import { Feature } from '../featureToggles/features';
+import { settMinusbeløpManuelt } from '../services/rest-service';
+
+const SettManueltMinusbeløp: FunctionComponent = () => {
+    const { korreksjonId } = useParams<{ korreksjonId: string }>();
+    const [belop, setBelop] = useState<string>('');
+    const featureToggles = useFeatureToggles();
+
+    if (!featureToggles[Feature.OpprettNullBelopKorreksjon]) {
+        return null;
+    } else {
+        return (
+            <div>
+                <TextField
+                    size="small"
+                    label={`Refusjonsbeløpet på grunn av fravær`}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                        const verdi: string = event.currentTarget.value;
+                        if (verdi.match(/^\d*$/)) {
+                            setBelop(verdi);
+                        }
+                        if (!verdi) {
+                            setBelop('');
+                        }
+                    }}
+                    onBlur={() => settMinusbeløpManuelt(korreksjonId!, parseInt(belop, 10))}
+                    value={belop}
+                />
+            </div>
+        );
+    }
+};
+
+export default SettManueltMinusbeløp;

--- a/src/featureToggles/features.ts
+++ b/src/featureToggles/features.ts
@@ -1,4 +1,5 @@
 export enum Feature {
     Reberegning = 'reberegningKnapp',
     OpprettNullBelopKorreksjon = 'opprettNullBelopKorreksjon',
+    ManueltMinusbelop = 'manueltMinusbelop',
 }

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -183,7 +183,7 @@ export const sjekkReberegning = async (refusjonId: string, harFerietrekkForSamme
 };
 
 export const settMinusbeløpManuelt = async (korreksjonId: string, beløp: number) => {
-    const response = await api.put(`/korreksjon/${korreksjonId}/sett-minusbeløp-manuelt`, { minusbeløp: beløp });
+    const response = await api.put(`/korreksjon/${korreksjonId}/sett-manuelt-minusbelop`, { minusbeløp: beløp });
     await mutate(`/korreksjon/${korreksjonId}`);
     return response.data;
 };

--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -65,7 +65,7 @@ export const useHentRefusjon = (refusjonId: string) => {
 export const hentHendelser = async (refusjonId: string) => {
     const response = await api.get<Hendelse[]>(`/refusjon/${refusjonId}/hendelselogg`);
     return response.data;
-}
+};
 
 export const useHentKorreksjon = (korreksjonId: string) => {
     const { data } = useSWR<Korreksjon>(`/korreksjon/${korreksjonId}`, swrConfig);
@@ -179,5 +179,11 @@ export const sjekkReberegning = async (refusjonId: string, harFerietrekkForSamme
         harFerietrekkForSammeMåned,
         minusBeløp,
     });
+    return response.data;
+};
+
+export const settMinusbeløpManuelt = async (korreksjonId: string, beløp: number) => {
+    const response = await api.put(`/korreksjon/${korreksjonId}/sett-minusbeløp-manuelt`, { minusbeløp: beløp });
+    await mutate(`/korreksjon/${korreksjonId}`);
     return response.data;
 };


### PR DESCRIPTION
 Mulighet for å sette et minusbeløp manuelt. Er feature-togglet bort bak en ny toggle. Kan brukes i spesialtilfeller der vi har merket et minusbeløp i minusbeløptabellen for oppgjort, selvom det ikke er det.

![image](https://github.com/navikt/tiltak-refusjon-saksbehandler/assets/5412607/9ec1bd13-957b-4afd-b21a-26b38dfe8ce5)
