### PR TITLE
Legg til exhaustiveness-sjekk

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,15 @@
         "test": "craco test"
     },
     "eslintConfig": {
-        "extends": "react-app"
+        "extends": "react-app",
+        "parserOptions": {
+            "project": [
+                "./tsconfig.json"
+            ]
+        },
+        "rules": {
+            "@typescript-eslint/switch-exhaustiveness-check": "error"
+        }
     },
     "browserslist": {
         "production": [


### PR DESCRIPTION
Denne konfigurasjonsendringen fører til at vi sjekker om en switch/case er "exhaustive", altså om den dekker alle tilfeller.

Veldig lurt!