### PR TITLE
Fiks labs

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,19 +9,19 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "axios": "1.7.2",
+                "axios": "1.7.7",
                 "dotenv": "16.4.5",
-                "express": "4.19.2",
+                "express": "4.20.0",
                 "express-async-handler": "1.2.0",
-                "express-http-proxy": "2.0.0",
+                "express-http-proxy": "2.1.1",
                 "helmet": "7.1.0",
-                "http-proxy-middleware": "2.0.6",
+                "http-proxy-middleware": "3.0.2",
                 "jsonwebtoken": "9.0.2",
                 "jwks-rsa": "3.1.0",
                 "node-cache": "5.1.2",
-                "openid-client": "5.6.5",
+                "openid-client": "5.7.0",
                 "tunnel": "0.0.6",
-                "winston": "3.13.0"
+                "winston": "3.14.2"
             }
         },
         "node_modules/@colors/colors": {
@@ -93,10 +93,9 @@
             "license": "MIT"
         },
         "node_modules/@types/http-proxy": {
-            "version": "1.17.14",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-            "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
-            "license": "MIT",
+            "version": "1.17.15",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+            "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -201,9 +200,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -211,9 +210,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -223,7 +222,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -245,6 +244,20 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/body-parser/node_modules/qs": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "dependencies": {
+                "side-channel": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/braces": {
             "version": "3.0.3",
@@ -457,7 +470,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -539,7 +551,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -551,36 +562,36 @@
             "license": "MIT"
         },
         "node_modules/express": {
-            "version": "4.19.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
+            "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "finalhandler": "1.2.0",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
                 "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.0",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -598,10 +609,9 @@
             "license": "MIT"
         },
         "node_modules/express-http-proxy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-2.0.0.tgz",
-            "integrity": "sha512-TXxcPFTWVUMSEmyM6iX2sT/JtmqhqngTq29P+eXTVFdtxZrTmM8THUYK59rUXiln0FfPGvxEpGRnVrgvHksXDw==",
-            "license": "MIT",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-2.1.1.tgz",
+            "integrity": "sha512-4aRQRqDQU7qNPV5av0/hLcyc0guB9UP71nCYrQEYml7YphTo8tmWf3nDZWdTJMMjFikyz9xKXaURor7Chygdwg==",
             "dependencies": {
                 "debug": "^3.0.1",
                 "es6-promise": "^4.1.1",
@@ -627,6 +637,14 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/express/node_modules/ms": {
@@ -736,7 +754,6 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -862,24 +879,33 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-            "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.2.tgz",
+            "integrity": "sha512-fBLFpmvDzlxdckwZRjM0wWtwDZ4KBtQ8NFqhrFKoEtK4myzuiumBuNTxD+F4cVbXfOZljIbrynmvByofDzT7Ag==",
             "dependencies": {
-                "@types/http-proxy": "^1.17.8",
+                "@types/http-proxy": "^1.17.15",
+                "debug": "^4.3.6",
                 "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
+                "is-glob": "^4.0.3",
+                "is-plain-object": "^5.0.0",
+                "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/http-proxy-middleware/node_modules/debug": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "dependencies": {
+                "ms": "^2.1.3"
             },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
+            "engines": {
+                "node": ">=6.0"
             },
             "peerDependenciesMeta": {
-                "@types/express": {
+                "supports-color": {
                     "optional": true
                 }
             }
@@ -946,16 +972,12 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-            "license": "MIT",
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-stream": {
@@ -1160,10 +1182,12 @@
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-            "license": "MIT"
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -1175,12 +1199,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "license": "MIT",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -1191,7 +1214,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -1298,11 +1320,11 @@
             }
         },
         "node_modules/openid-client": {
-            "version": "5.6.5",
-            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
-            "integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.0.tgz",
+            "integrity": "sha512-4GCCGZt1i2kTHpwvaC/sCpTpQqDnBzDzuJcJMbH+y1Q5qI8U8RBvoSh28svarXszZHR5BAMXbJPX1PGPRE3VOA==",
             "dependencies": {
-                "jose": "^4.15.5",
+                "jose": "^4.15.9",
                 "lru-cache": "^6.0.0",
                 "object-hash": "^2.2.0",
                 "oidc-token-hash": "^5.0.3"
@@ -1321,16 +1343,14 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-            "license": "MIT"
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -1381,7 +1401,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1466,10 +1485,9 @@
             }
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-            "license": "MIT",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -1493,7 +1511,6 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -1501,19 +1518,53 @@
         "node_modules/send/node_modules/debug/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-            "license": "MIT",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
+            "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
             "dependencies": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
                 "send": "0.18.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-static/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/serve-static/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/serve-static/node_modules/send": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -1687,15 +1738,15 @@
             }
         },
         "node_modules/winston": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-            "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+            "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
             "dependencies": {
                 "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.2",
                 "async": "^3.2.3",
                 "is-stream": "^2.0.0",
-                "logform": "^2.4.0",
+                "logform": "^2.6.0",
                 "one-time": "^1.0.0",
                 "readable-stream": "^3.4.0",
                 "safe-stable-stringify": "^2.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -4,18 +4,18 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "axios": "1.7.2",
+        "axios": "1.7.7",
         "dotenv": "16.4.5",
-        "express": "4.19.2",
+        "express": "4.20.0",
         "express-async-handler": "1.2.0",
-        "express-http-proxy": "2.0.0",
+        "express-http-proxy": "2.1.1",
         "helmet": "7.1.0",
-        "http-proxy-middleware": "2.0.6",
+        "http-proxy-middleware": "3.0.2",
         "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.1.0",
         "node-cache": "5.1.2",
-        "openid-client": "5.6.5",
+        "openid-client": "5.7.0",
         "tunnel": "0.0.6",
-        "winston": "3.13.0"
+        "winston": "3.14.2"
     }
 }

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -19,7 +19,7 @@ async function startLabs(server) {
         server.use(
             '/api',
             createProxyMiddleware({
-                target: 'http://tiltak-refusjon-api-labs',
+                target: 'http://tiltak-refusjon-api-labs/api',
                 changeOrigin: true,
                 on: {
                     proxyReq: (proxyReq, req, res, options) => {

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -38,7 +38,6 @@ async function startLabs(server) {
         );
 
         server.use('/logout', (req, res) => {
-            res.clearCookie('tokenx-token');
             res.clearCookie('aad-token');
             res.redirect('/');
         });

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -21,16 +21,18 @@ async function startLabs(server) {
             createProxyMiddleware({
                 target: 'http://tiltak-refusjon-api-labs',
                 changeOrigin: true,
-                onProxyReq: (proxyReq, req, res, options) => {
-                    const cookies = req.headers?.cookie?.split(';');
-                    const cookieWithFakeToken = cookies?.filter((c) => c.includes('aad-token'));
-                    if (!cookieWithFakeToken?.length) {
-                        res.writeHead(401);
-                        res.end();
-                        return;
-                    }
-                    const accessToken = cookieWithFakeToken[0].split('=')[1];
-                    proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                on: {
+                    proxyReq: (proxyReq, req, res, options) => {
+                        const cookies = req.headers?.cookie?.split(';');
+                        const cookieWithFakeToken = cookies?.filter((c) => c.includes('aad-token'));
+                        if (!cookieWithFakeToken?.length) {
+                            res.writeHead(401);
+                            res.end();
+                            return;
+                        }
+                        const accessToken = cookieWithFakeToken[0].split('=')[1];
+                        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                    },
                 },
             })
         );

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -21,18 +21,16 @@ async function startLabs(server) {
             createProxyMiddleware({
                 target: 'http://tiltak-refusjon-api-labs',
                 changeOrigin: true,
-                configure: (proxy) => {
-                    proxy.on('proxyReq', (proxyReq, req, res) => {
-                        const cookies = req.headers?.cookie?.split(';');
-                        const cookieWithFakeToken = cookies?.filter((c) => c === 'aad-token');
-                        if (!cookieWithFakeToken?.length) {
-                            res.writeHead(401);
-                            res.end();
-                            return;
-                        }
-                        const accessToken = cookieWithFakeToken[0].split('=')[1];
-                        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
-                    });
+                onProxyReq: (proxyReq, req, res, options) => {
+                    const cookies = req.headers?.cookie?.split(';');
+                    const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
+                    if (!cookieWithFakeToken?.length) {
+                        res.writeHead(401);
+                        res.end();
+                        return;
+                    }
+                    const accessToken = cookieWithFakeToken[0].split('=')[1];
+                    proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
                 },
             })
         );

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -23,7 +23,7 @@ async function startLabs(server) {
                 changeOrigin: true,
                 onProxyReq: (proxyReq, req, res, options) => {
                     const cookies = req.headers?.cookie?.split(';');
-                    const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
+                    const cookieWithFakeToken = cookies?.filter((c) => c.includes('aad-token'));
                     if (!cookieWithFakeToken?.length) {
                         res.writeHead(401);
                         res.end();

--- a/src/LokalLogin/LokalLogin.tsx
+++ b/src/LokalLogin/LokalLogin.tsx
@@ -18,7 +18,7 @@ const LokalLogin: FunctionComponent<Props> = (props) => {
 
     const loggInnKnapp = async (subject: string) => {
         const response = await axios.get(
-            `https://tiltak-fakelogin.ekstern.dev.nav.no/token?aud=aud-aad&iss=aad&sub=${subject}&NAVident=${subject}&oid=00000000-0000-0000-0000-000000000000`
+            `https://tiltak-fakelogin.ekstern.dev.nav.no/token?aud=aud-aad&iss=aad&sub=${subject}&NAVident=${subject}&oid=00000000-0000-0000-0000-000000000000&groups=abcd1234`
         );
         document.cookie = `${AAD_COOKIE_NAME}=${response.data};expires=Tue, 15 Jan 2044 21:47:38 GMT;domain=${window.location.hostname};path=/`;
         window.location.reload();

--- a/src/LokalLogin/LokalLogin.tsx
+++ b/src/LokalLogin/LokalLogin.tsx
@@ -18,7 +18,7 @@ const LokalLogin: FunctionComponent<Props> = (props) => {
 
     const loggInnKnapp = async (subject: string) => {
         const response = await axios.get(
-            `https://tiltak-fakelogin.ekstern.dev.nav.no/token?aud=aud-aad&iss=aad&sub=${subject}&NAVident=${subject}&oid=00000000-0000-0000-0000-000000000000&groups=abcd1234`
+            `https://tiltak-fakelogin.ekstern.dev.nav.no/token?aud=aud-aad&iss=aad&sub=${subject}&NAVident=${subject}&oid=00000000-0000-0000-0000-000000000000&groups=BESLUTTER_AD_GRUPPE`
         );
         document.cookie = `${AAD_COOKIE_NAME}=${response.data};expires=Tue, 15 Jan 2044 21:47:38 GMT;domain=${window.location.hostname};path=/`;
         window.location.reload();


### PR DESCRIPTION
En oppgradering av backenden har fjernet støtte for
"authtoken-cookies", så proxyen bør sende inn token
i authorization-header.

En fordel med denne endringen er at backenden ikke
lenger må forholde seg til både arbeidsgiver og
saksbehandler-tokenet ved tilgangssjekk, som potensielt
kan føre til merkelige feil hvor feks en beslutter blir antatt
å være en arbeidsgiver når man er logget inn i begge
tjenester.

I tillegg manglet beslutter-gruppen i "fake-tokenet", så for
å blidgjøre backenden setter vi inn en dummy-verdi som
også er definert i api-kodebasen.

En oppgradering av http-proxy-middleware hadde også
to breaking changes:
* vi må eksplisitt peke mot riktig path i target-feltet
* onProxyReq er flyttet til {on:{proxyReq: ...}}