### PR TITLE
Fiks syncmode for modia-dekoratøren

### DIFF
--- a/src/InternflateDekoratør.tsx
+++ b/src/InternflateDekoratør.tsx
@@ -9,6 +9,8 @@ export interface DecoratorProps {
     enableHotkeys?: boolean | undefined; // Aktivere hurtigtaster
     fetchActiveEnhetOnMount?: boolean | undefined; // Om enhet er undefined fra container appen, og denne er satt til true, henter den sist aktiv enhet og bruker denne.
     fetchActiveUserOnMount?: boolean | undefined; // Om fnr er undefined fra container appen, og denne er satt til true for at den skal hente siste aktiv fnr.
+    fnrSyncMode?: 'sync' | 'writeOnly'; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
+    enhetSyncMode?: 'sync' | 'writeOnly'; // Samme som fnrSyncMode, men for enhet state.
     onEnhetChanged: (enhetId?: string | null, enhet?: Enhet) => void; // Kalles når enheten endres
     onFnrChanged: (fnr?: string | null) => void; // Kalles når fnr enheten endres
     onLinkClick?: (link: { text: string; url: string }) => void; // Kan brukes for å legge til callbacks ved klikk på lenker i menyen. Merk at callbacken ikke kan awaites og man må selv håndtere at siden lukkes. Nyttig for å f.eks tracke navigasjon events i amplitude
@@ -82,6 +84,8 @@ const InternflateDekoratør: FunctionComponent = () => {
             onFnrChanged={() => {}}
             fetchActiveUserOnMount={false}
             fetchActiveEnhetOnMount={false}
+            fnrSyncMode="writeOnly"
+            enhetSyncMode="writeOnly"
             showEnheter={false}
             showSearchArea={false}
             showHotkeys={false}


### PR DESCRIPTION
Denne endringen gjør at vi ikke får popups som
advarer om at enhet/fnr har endret seg i et annet
vindu.