### PR TITLE
Oppdater URL til contextholder.

### DIFF
--- a/server/src/proxy/decorator-proxy.js
+++ b/server/src/proxy/decorator-proxy.js
@@ -21,7 +21,7 @@ const setup = (router, authClient, tokenEndpoint) => {
             }
         },
         createProxyMiddleware({
-            target: 'http://modiacontextholder.personoversikt/modiacontextholder',
+            target: 'http://modiacontextholder.personoversikt',
             followRedirects: false,
             changeOrigin: true,
         })


### PR DESCRIPTION
`/modiacontextholder` base pathen eksisterer kun for kompatibilitet med
gamle ingresser og skal fjernes.
