### PR TITLE
Endre modia-dekorator-props

### DIFF
--- a/src/InternflateDekoratør.tsx
+++ b/src/InternflateDekoratør.tsx
@@ -82,8 +82,8 @@ const InternflateDekoratør: FunctionComponent = () => {
             proxy="/modiacontextholder"
             onEnhetChanged={() => {}}
             onFnrChanged={() => {}}
-            fetchActiveUserOnMount={false}
-            fetchActiveEnhetOnMount={false}
+            fetchActiveUserOnMount={true}
+            fetchActiveEnhetOnMount={true}
             fnrSyncMode="writeOnly"
             enhetSyncMode="writeOnly"
             showEnheter={false}


### PR DESCRIPTION
Hvis vi ikke henter aktiv enhet og user on mount
vil veiledere få et plagsomt varsel om at de har
byttet enhet i andre nettleserfaner.