### PR TITLE
Modiadekoratøren - syncMode ignore

### DIFF
--- a/src/InternflateDekoratør.tsx
+++ b/src/InternflateDekoratør.tsx
@@ -9,8 +9,8 @@ export interface DecoratorProps {
     enableHotkeys?: boolean | undefined; // Aktivere hurtigtaster
     fetchActiveEnhetOnMount?: boolean | undefined; // Om enhet er undefined fra container appen, og denne er satt til true, henter den sist aktiv enhet og bruker denne.
     fetchActiveUserOnMount?: boolean | undefined; // Om fnr er undefined fra container appen, og denne er satt til true for at den skal hente siste aktiv fnr.
-    fnrSyncMode?: 'sync' | 'writeOnly'; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
-    enhetSyncMode?: 'sync' | 'writeOnly'; // Samme som fnrSyncMode, men for enhet state.
+    fnrSyncMode?: 'sync' | 'writeOnly' | 'ignore'; // Modus til fnr state management. "sync" er default. "writeOnly" gjør at endringer aldri hentes men vil settes dersom det oppdateres lokalt i appen
+    enhetSyncMode?: 'sync' | 'writeOnly' | 'ignore'; // Samme som fnrSyncMode, men for enhet state.
     onEnhetChanged: (enhetId?: string | null, enhet?: Enhet) => void; // Kalles når enheten endres
     onFnrChanged: (fnr?: string | null) => void; // Kalles når fnr enheten endres
     onLinkClick?: (link: { text: string; url: string }) => void; // Kan brukes for å legge til callbacks ved klikk på lenker i menyen. Merk at callbacken ikke kan awaites og man må selv håndtere at siden lukkes. Nyttig for å f.eks tracke navigasjon events i amplitude
@@ -84,8 +84,8 @@ const InternflateDekoratør: FunctionComponent = () => {
             onFnrChanged={() => {}}
             fetchActiveUserOnMount={true}
             fetchActiveEnhetOnMount={true}
-            fnrSyncMode="writeOnly"
-            enhetSyncMode="writeOnly"
+            fnrSyncMode="ignore"
+            enhetSyncMode="ignore"
             showEnheter={false}
             showSearchArea={false}
             showHotkeys={false}


### PR DESCRIPTION
Opplever fortsatt et par problemer med popups
om at enhet har endret seg når man veksler mellom
applikasjoner. Denne gang er det andre applikasjoner som får en popup når man åpner våre apper.

Konfigurerer nå syncmode til "ignore", en ny option som har blitt laget for å forhåpentligvis løse denne floken.